### PR TITLE
NCipher#configureの定義

### DIFF
--- a/lib/n_cipher.rb
+++ b/lib/n_cipher.rb
@@ -6,6 +6,24 @@ module NCipher
   @seed = 'にゃんぱす'
   @delimiter = '〜'
 
+  # シード値、区切り文字を設定するためのモジュール
+  module Configuration
+    # @!attribute seed
+    #   シード値
+    # @!attribute delimiter
+    #   区切り文字
+    attr_accessor :seed, :delimiter
+
+    # @example
+    #   NCipher.configure do |config|
+    #     config.seed = 'abc'
+    #     config.delimiter = ','
+    #   end
+    def configure
+      yield self
+    end
+  end
+
   # 実際の暗号化、復号化を行うメソッドが定義されているモジュール
   # @note このモジュール内のメソッドはプライベートクラスメソッドに指定されているため、外部から呼び出すことはできない
   module Convert
@@ -63,7 +81,7 @@ module NCipher
   end
 
   class << self
-    attr_accessor :seed, :delimiter
+    include NCipher::Configuration
     include NCipher::Convert
 
     # 文字列を暗号化

--- a/test/test_configuration.rb
+++ b/test/test_configuration.rb
@@ -1,0 +1,27 @@
+require 'n_cipher'
+
+class ConfigurationTest < Test::Unit::TestCase
+  test 'メソッド呼び出し' do
+    assert_respond_to NCipher, :configure
+  end
+
+  test 'シード値設定' do
+    NCipher.configure {|config| config.seed = '890' }
+    old = NCipher.encode 'abc'
+
+    NCipher.configure {|config| config.seed = '123' }
+    new = NCipher.encode 'abc'
+
+    assert_not_equal old, new
+  end
+
+  test 'デリミタ設定' do
+    NCipher.configure {|config| config.delimiter = ',' }
+    old = NCipher.encode 'abc'
+
+    NCipher.configure {|config| config.delimiter = '-' }
+    new = NCipher.encode 'abc'
+
+    assert_not_equal old, new
+  end
+end

--- a/test/test_decode.rb
+++ b/test/test_decode.rb
@@ -1,6 +1,13 @@
 require 'n_cipher'
 
 class DecodeTest < Test::Unit::TestCase
+  def setup
+    NCipher.configure do |config|
+      config.seed = 'にゃんぱす'
+      config.delimiter = '〜'
+    end
+  end
+
   sub_test_case '正常系' do
     test '通常利用想定' do
       assert_equal('にゃんぱす',

--- a/test/test_encode.rb
+++ b/test/test_encode.rb
@@ -1,6 +1,13 @@
 require 'n_cipher'
 
 class EncodeTest < Test::Unit::TestCase
+  def setup
+    NCipher.configure do |config|
+      config.seed = 'にゃんぱす'
+      config.delimiter = '〜'
+    end
+  end
+
   sub_test_case '正常系' do
     test '文字列のみ' do
       assert_equal('ぱすすにすに〜ぱすすゃぱす〜ぱすすんんに〜ぱすすゃにゃ〜ぱすすににん〜',


### PR DESCRIPTION
こんな感じでシード値、区切り文字を設定できるようにしたい

``` ruby
# 特に設定してなければデフォルト値が使われる
#   シード値: にゃんぱす
#   区切り文字: 〜
p NCipher.encode 'abc'
#=> "ぱすん〜ぱすぱ〜ぱすす〜"

# NCipher.configure do 〜 end内で定義
# 以後、設定した値が使われる
#   シード値: おうどん
#   区切り文字: ひげ
NCipher.configure do |config|
  config.seed = 'おうどん'
  config.delimiter = 'ひげ'
end

p NCipher.encode 'abc'
#=> "うどおうひげうどおどひげうどおんひげ"
```
